### PR TITLE
update String interface implementation to return "<nil>"

### DIFF
--- a/enumflag.go
+++ b/enumflag.go
@@ -176,7 +176,7 @@ func (e *EnumValue) String() string {
 			return ids[0]
 		}
 	}
-	return "<unknown>"
+	return "<nil>"
 }
 
 // Type returns the name of the flag value type. The type name is used in error


### PR DESCRIPTION
update String interface implementation to return `"\<nil>"` instead of `"\<unknown>"`
`
per https://github.com/spf13/pflag/blob/d5e0c0615acee7028e1e2740a11102313be88de1/flag.go#L557 pflag uses the value returned by `String()` to determine if a default string should be appended in the help message.  When no default should show we should set "<nil>" here instead so that pflag correctly does not print "default <unknown>" in the help message.