### PR TITLE
doc: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ In other situations you might _not_ want to have a default value set, because a
 particular CLI flag is mandatory (using cobra's
 [MarkFlagRequired](https://pkg.go.dev/github.com/spf13/cobra#MarkFlagRequired)).
 Here, cobra's help should not show a (useless) default enum flag setting but
-only the availabe enum values.
+only the available enum values.
 
 **Don't assign the zero value** of your enum type to any value, except the
 "non-existing" default.
@@ -370,14 +370,14 @@ The included `enumflag.code-workspace` defines the following tasks:
 
 #### Aux Tasks
 
-- _pksite service_: auxilliary task to run `pkgsite` as a background service
+- _pksite service_: auxiliary task to run `pkgsite` as a background service
   using `scripts/pkgsite.sh`. The script leverages browser-sync and nodemon to
   hot reload the Go module documentation on changes; many thanks to @mdaverde's
   [_Build your Golang package docs
   locally_](https://mdaverde.com/posts/golang-local-docs) for paving the way.
   `scripts/pkgsite.sh` adds automatic installation of `pkgsite`, as well as the
   `browser-sync` and `nodemon` npm packages for the local user.
-- _view pkgsite_: auxilliary task to open the VSCode-integrated "simple" browser
+- _view pkgsite_: auxiliary task to open the VSCode-integrated "simple" browser
   and pass it the local URL to open in order to show the module documentation
   rendered by `pkgsite`. This requires a detour via a task input with ID
   "_pkgsite_".

--- a/mapper.go
+++ b/mapper.go
@@ -26,7 +26,7 @@ import (
 // EnumIdentifiers maps enumeration values to their corresponding textual
 // representations (~identifiers). This mapping is a one-to-many mapping in that
 // the same enumeration value may have more than only one associated textual
-// representation (indentifier). If more than one textual representation exists
+// representation (identifier). If more than one textual representation exists
 // for the same enumeration value, then the first textual representation is
 // considered to be the canonical one.
 type EnumIdentifiers[E constraints.Integer] map[E][]string
@@ -62,7 +62,7 @@ func (m enumMapper[E]) ValueOf(name string) (E, error) {
 		comparefn = func(s string) bool { return strings.ToLower(s) == name }
 	}
 	// Try to find a matching enum value textual representation, and then take
-	// its enumation value ("code").
+	// its enumeration value ("code").
 	for enumval, ids := range m.m {
 		if slices.IndexFunc(ids, comparefn) >= 0 {
 			return enumval, nil


### PR DESCRIPTION
Found via `typos --hidden --format brief`